### PR TITLE
Fix typo in Embedding docstring: weight -> weights

### DIFF
--- a/minitorch/modules_basic.py
+++ b/minitorch/modules_basic.py
@@ -27,7 +27,7 @@ class Embedding(Module):
             embedding_dim : The size of each embedding vector
 
         Attributes:
-            weight : The learnable weights of shape (num_embeddings, embedding_dim) initialized from N(0, 1).
+            weights : The learnable weights of shape (num_embeddings, embedding_dim) initialized from N(0, 1).
         """
         self.backend = backend
         self.num_embeddings = num_embeddings # Vocab size


### PR DESCRIPTION
Fixed a typo in the `Embedding` class docstring where the attribute was incorrectly documented as `weight` instead of `weights`. This is becauce the test file `tests/test_modules_basic_student.py` expects the attribute to be named `weights`
https://github.com/llmsystem/llmsys_hw3/blob/main/tests/test_modules_basic_student.py#L48