### PR TITLE
Downgrade datasets version to support loading scripts

### DIFF
--- a/requirements.extra.txt
+++ b/requirements.extra.txt
@@ -1,5 +1,5 @@
 torch==2.9.1
-datasets==4.4.1
+datasets==3.4.0
 tokenizers
 transformers
 fire


### PR DESCRIPTION
After `datasets==4.0.0` using loading scripts are banned. source: https://discuss.huggingface.co/t/dataset-scripts-are-no-longer-supported/163891

However the dataset used in this homework requires a script to load in here: https://huggingface.co/datasets/bbaaaa/iwslt14-de-en-preprocess/blob/main/iwslt14-de-en-preprocess.py

The simple fix here is to downgrade datasets to 3.4.0