### PR TITLE
Fix Adam second-moment beta coefficient

### DIFF
--- a/minitorch/optim.py
+++ b/minitorch/optim.py
@@ -65,7 +65,7 @@ class Adam(Optimizer):
 
                     state['step'] += 1
                     state['exp_avg'] = state['exp_avg'] * self.beta1 + (1 - self.beta1) * grad
-                    state['exp_avg_sq'] = state['exp_avg_sq'] * self.beta2 + (1 - self.beta1) * grad ** 2
+                    state['exp_avg_sq'] = state['exp_avg_sq'] * self.beta2 + (1 - self.beta2) * grad ** 2
 
                     # denom = exp_avg_sq.sqrt().add_(group['eps'])
                     denom = state['exp_avg_sq'] ** 0.5 + self.eps


### PR DESCRIPTION
Fixes a typo in Adam's second moment update in minitorch/optim.py by using (1 - beta2) instead of (1 - beta1) for exp_avg_sq.