### PR TITLE
Handle non-contiguous grad_output in View.backward

### DIFF
--- a/minitorch/tensor_functions.py
+++ b/minitorch/tensor_functions.py
@@ -381,6 +381,10 @@ class View(Function):
     @staticmethod
     def backward(ctx: Context, grad_output: Tensor) -> Tuple[Tensor, float]:
         (original,) = ctx.saved_values
+        if not grad_output._tensor.is_contiguous():
+            buf = grad_output.zeros(grad_output.shape)
+            grad_output.f.id_map(grad_output, buf)
+            grad_output = buf
         return (
             minitorch.Tensor.make(
                 grad_output._tensor._storage, original, backend=grad_output.backend


### PR DESCRIPTION
View.backward reinterprets grad_output._tensor._storage directly with the original shape, assuming it is contiguous. This causes incorrect gradient calculations if grad_output is not contiguous (such as from Permute.backward). This PR fixes the issue by copying its data into a contiguous buffer using id_map before reinterpreting the storage.