### PR TITLE
Change reduce_value type from double to float in CudaKernelOps

### DIFF
--- a/minitorch/cuda_kernel_ops.py
+++ b/minitorch/cuda_kernel_ops.py
@@ -165,7 +165,7 @@ class CudaKernelOps(TensorOps):
                 np.ctypeslib.ndpointer(dtype=np.int32, ndim=1, flags='C_CONTIGUOUS'),    # in_shape
                 np.ctypeslib.ndpointer(dtype=np.int32, ndim=1, flags='C_CONTIGUOUS'),    # in_strides
                 ctypes.c_int,                                                            # reduce_dim
-                ctypes.c_double,                                                         # reduce_value
+                ctypes.c_float,                                                         # reduce_value
                 ctypes.c_int,                                                            # shape_len
                 ctypes.c_int,                                                            # fn_id
             ]


### PR DESCRIPTION
Fixes data type mismatch between the Python binding and CUDA code (which expects a float), potentially leading to nan gradients. See https://edstem.org/us/courses/89798/discussion/7693487